### PR TITLE
prevent seconds from running when freezeTime enabled.

### DIFF
--- a/client/client.lua
+++ b/client/client.lua
@@ -113,6 +113,7 @@ CreateThread(function()
             end
             if freezeTime then
                 timeOffset = timeOffset + baseTime - newBaseTime
+                second = 0
             end
             baseTime = newBaseTime
             hour = math.floor(((baseTime+timeOffset)/60)%24)


### PR DESCRIPTION
When the seconds exceed the amount of seconds required to make up a minute, the game will allow for a minute to have passed.

We have to ensure, when time is frozen, to set the second variable back to 0 for the duration of the freezetime, to prevent time from still passing.

This fixes issue #44 