### PR TITLE
Reworking time sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,8 +188,6 @@ const state = global.exports["qb-weathersync"].getDynamicWeather();
 
 `qb-weathersync:server:RequestStateSync` - Sync time and weather for everyone
 
-`qb-weathersync:server:RequestCommands` - Check if permission avaiable for client
-
 `qb-weathersync:server:setWeather` [type] - Set Weather type (List in Config)
 
 `qb-weathersync:server:setTime` [hour] (minute) - Set simulated time

--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ to adjust weather patterns you need to modify nextWeatherStage() in `server/serv
 
 `/time [hour] (minute)` - Set time to whatever you want
 
+`/resettime` - Resets time to real time
+
 ## Exports
 
 ### nextWeatherStage
@@ -96,6 +98,18 @@ local success = exports["qb-weathersync"]:setTime(8, 10); -- 8:10 AM
 ```js
 // JAVASCRIPT EXAMPLE
 const success = global.exports["qb-weathersync"].setTime(15, 30); // 3:30PM
+```
+
+
+### resetTime
+Resets sun position based on real time
+```lua
+-- LUA EXAMPLE
+local success = exports["qb-weathersync"]:resetTime();
+```
+```js
+// JAVASCRIPT EXAMPLE
+const success = global.exports["qb-weathersync"].resetTime();
 ```
 
 
@@ -191,6 +205,8 @@ const state = global.exports["qb-weathersync"].getDynamicWeather();
 `qb-weathersync:server:setWeather` [type] - Set Weather type (List in Config)
 
 `qb-weathersync:server:setTime` [hour] (minute) - Set simulated time
+
+`qb-weathersync:server:resetTime` - Resets time to the current server OS real time
 
 `qb-weathersync:server:toggleBlackout` (true|false) - Enable, disable or toggle blackout
 

--- a/client/client.lua
+++ b/client/client.lua
@@ -11,7 +11,6 @@ local disable = Config.Disabled
 RegisterNetEvent('QBCore:Client:OnPlayerLoaded', function()
     disable = false
     TriggerServerEvent('qb-weathersync:server:RequestStateSync')
-    TriggerServerEvent('qb-weathersync:server:RequestCommands')
 end)
 
 RegisterNetEvent('qb-weathersync:client:EnableSync', function()
@@ -36,25 +35,6 @@ end)
 RegisterNetEvent('qb-weathersync:client:SyncWeather', function(NewWeather, newblackout)
     CurrentWeather = NewWeather
     blackout = newblackout
-end)
-
-RegisterNetEvent('qb-weathersync:client:RequestCommands', function(isAllowed)
-    if isAllowed then
-        TriggerEvent('chat:addSuggestion', '/freezetime', Lang:t('help.freezecommand'), {})
-        TriggerEvent('chat:addSuggestion', '/freezeweather', Lang:t('help.freezeweathercommand'), {})
-        TriggerEvent('chat:addSuggestion', '/weather', Lang:t('help.weathercommand'), {
-            { name=Lang:t('help.weathertype'), help=Lang:t('help.availableweather') }
-        })
-        TriggerEvent('chat:addSuggestion', '/blackout', Lang:t('help.blackoutcommand'), {})
-        TriggerEvent('chat:addSuggestion', '/morning', Lang:t('help.morningcommand'), {})
-        TriggerEvent('chat:addSuggestion', '/noon', Lang:t('help.nooncommand'), {})
-        TriggerEvent('chat:addSuggestion', '/evening', Lang:t('help.eveningcommand'), {})
-        TriggerEvent('chat:addSuggestion', '/night', Lang:t('help.nightcommand'), {})
-        TriggerEvent('chat:addSuggestion', '/time', Lang:t('help.timecommand'), {
-            { name=Lang:t('help.timehname'), help=Lang:t('help.timeh') },
-            { name=Lang:t('help.timemname'), help=Lang:t('help.timem') }
-        })
-    end
 end)
 
 RegisterNetEvent('qb-weathersync:client:SyncTime', function(base, offset, freeze)

--- a/client/client.lua
+++ b/client/client.lua
@@ -19,17 +19,17 @@ RegisterNetEvent('qb-weathersync:client:EnableSync', function()
 end)
 
 RegisterNetEvent('qb-weathersync:client:DisableSync', function()
-	disable = true
-	CreateThread(function()
-		while disable do
-			SetRainLevel(0.0)
-			SetWeatherTypePersist('CLEAR')
-			SetWeatherTypeNow('CLEAR')
-			SetWeatherTypeNowPersist('CLEAR')
-			NetworkOverrideClockTime(18, 0, 0)
-			Wait(5000)
-		end
-	end)
+    disable = true
+    CreateThread(function()
+        while disable do
+            SetRainLevel(0.0)
+            SetWeatherTypePersist('CLEAR')
+            SetWeatherTypeNow('CLEAR')
+            SetWeatherTypeNowPersist('CLEAR')
+            NetworkOverrideClockTime(18, 0, 0)
+            Wait(5000)
+        end
+    end)
 end)
 
 RegisterNetEvent('qb-weathersync:client:SyncWeather', function(NewWeather, newblackout)
@@ -51,7 +51,7 @@ CreateThread(function()
                 SetWeatherTypeOverTime(CurrentWeather, 15.0)
                 Wait(15000)
             end
-            Wait(100) -- Wait 0 seconds to prevent crashing.
+            Wait(0)-- Wait 0 seconds to prevent crashing.
             SetArtificialLightsState(blackout)
             SetArtificialLightsStateAffectsVehicles(blackoutVehicle)
             ClearOverrideWeather()
@@ -82,26 +82,22 @@ end)
 CreateThread(function()
     local hour = 0
     local minute = 0
-    local second = 0        --Add seconds for shadow smoothness
+    local second = 0 --Add seconds for shadow smoothness
     while true do
         if not disable then
             Wait(0)
-            local newBaseTime = baseTime
-            if GetGameTimer() - 22  > timer then    --Generate seconds in client side to avoid communiation
-                second = second + 1                 --Minutes are sent from the server every 2 seconds to keep sync
+            if GetGameTimer() - 22 > timer then --Generate seconds in client side to avoid communiation
+                second = second + 1 --Minutes are sent from the server every 2 seconds to keep sync
                 timer = GetGameTimer()
             end
-            if freezeTime then
-                timeOffset = timeOffset + baseTime - newBaseTime
+            
+            hour = math.floor(((baseTime + timeOffset + Config.GMTOffset) / 3600) % 24)
+            local newMinute = math.floor(((baseTime + timeOffset) / 60) % 60)
+            if minute ~= newMinute then --Reset seconds to 0 when new minute
+                minute = newMinute
                 second = 0
             end
-            baseTime = newBaseTime
-            hour = math.floor(((baseTime+timeOffset)/60)%24)
-            if minute ~= math.floor((baseTime+timeOffset)%60) then  --Reset seconds to 0 when new minute
-                minute = math.floor((baseTime+timeOffset)%60)
-                second = 0
-            end
-            NetworkOverrideClockTime(hour, minute, second)          --Send hour included seconds to network clock time
+            NetworkOverrideClockTime(hour, minute, second)--Send hour included seconds to network clock time
         else
             Wait(1000)
         end

--- a/config.lua
+++ b/config.lua
@@ -11,6 +11,8 @@ Config.BlackoutVehicle  = false -- Set blackout affects vehicles                
 Config.NewWeatherTimer  = 10 -- Time (in minutes) between each weather change   default: 10
 Config.Disabled         = false -- Set weather disabled                         default: false
 
+Config.GMT = 2 -- Change this to your local time zone
+Config.GMTOffset = Config.GMT * 3600 -- DONT TOUCH!
 
 Config.AvailableWeatherTypes = { -- DON'T TOUCH EXCEPT IF YOU KNOW WHAT YOU ARE DOING
     'EXTRASUNNY',

--- a/locales/da.lua
+++ b/locales/da.lua
@@ -54,10 +54,6 @@ local Translations = {
         nightcommand = 'Sæt tiden til 23:00',
         blackoutcommand = 'Slå blackout til/fra .',
     },
-    error = {
-        not_access = 'Du har ikke adgang til denne command.',
-        not_allowed = 'Du har ikke tilladelse til at bruge denne command.',
-    }
 }
 
     Lang = Locale:new({

--- a/locales/da.lua
+++ b/locales/da.lua
@@ -46,6 +46,7 @@ local Translations = {
         timemname = 'minutter',
         timeh = 'Et nummer mellem 0 - 23',
         timem = 'Et nummer mellem 0 - 59',
+        resettimecommand = 'Nulstiller tiden til realtid',
         freezecommand = 'Stop / kør tiden.',
         freezeweathercommand = 'Slå til/fra dynamiske vejr ændringer.',
         morningcommand = 'Sæt tiden til 09:00',

--- a/locales/de.lua
+++ b/locales/de.lua
@@ -52,10 +52,6 @@ local Translations = {
         nightcommand = 'Uhrzeit auf 23:00 Uhr einstellen',
         blackoutcommand = 'Blackoutmodus ein- und ausschalten.',
     },
-    error = {
-        not_access = 'Du hast keinen Zugriff auf diesen Befehl.',
-        not_allowed = 'Du bist nicht berechtigt, diesen Befehl zu verwenden.',
-    }
 }
 
     Lang = Locale:new({

--- a/locales/de.lua
+++ b/locales/de.lua
@@ -44,6 +44,7 @@ local Translations = {
         timemname = 'Minuten',
         timeh = 'Eine Zahl zwischen 0 - 23',
         timem = 'Eine Zahl zwischen 0 - 59',
+        resettimecommand = 'Setzt die Zeit auf Echtzeit zurück',
         freezecommand = 'Uhrzeit Einfrieren/Auftauen.',
         freezeweathercommand = 'Aktivieren/Deaktivieren der dynamischen Wetteränderungen.',
         morningcommand = 'Uhrzeit auf 09:00 Uhr einstellen',

--- a/locales/en.lua
+++ b/locales/en.lua
@@ -52,10 +52,6 @@ local Translations = {
         nightcommand = 'Set the time to 23:00',
         blackoutcommand = 'Toggle blackout mode.',
     },
-    error = {
-        not_access = 'You do not have access to that command.',
-        not_allowed = 'You are not allowed to use this command.',
-    }
 }
 
     Lang = Locale:new({

--- a/locales/en.lua
+++ b/locales/en.lua
@@ -44,6 +44,7 @@ local Translations = {
         timemname = 'minutes',
         timeh = 'A number between 0 - 23',
         timem = 'A number between 0 - 59',
+        resettimecommand = 'Resets time to real time',
         freezecommand = 'Freeze / unfreeze time.',
         freezeweathercommand = 'Enable/disable dynamic weather changes.',
         morningcommand = 'Set the time to 09:00',

--- a/locales/fr.lua
+++ b/locales/fr.lua
@@ -52,10 +52,6 @@ local Translations = {
         nightcommand = 'Met le temps à 23:00',
         blackoutcommand = 'Active la coupure électrique',
     },
-    error = {
-        not_access = "Erreur : Vous n'avez pas accès à cette commande.",
-        not_allowed = "Erreur : Vous n'avez pas accès à cette commande.",
-    }
 }
 
     Lang = Locale:new({

--- a/locales/fr.lua
+++ b/locales/fr.lua
@@ -44,6 +44,7 @@ local Translations = {
         timemname = 'minutes',
         timeh = 'Un nombre entre 0 - 23',
         timem = 'Un nombre entre 0 - 59',
+        resettimecommand = "Remise à l'heure réelle",
         freezecommand = 'gèle / dégèle le temps.',
         freezeweathercommand = 'Active/désactive le changement de temps dynamique.',
         morningcommand = 'Met le temps à 09:00',

--- a/locales/hu.lua
+++ b/locales/hu.lua
@@ -52,10 +52,6 @@ local Translations = {
         nightcommand = 'Id? megváltoztatva: 23:00',
         blackoutcommand = 'Áramszünet mód ki/be kapcsolása.',
     },
-    error = {
-        not_access = 'Nincs jogosultságod a parancs használatára.',
-        not_allowed = 'Nincs jogosultságod a parancs használatára.',
-    }
 }
 
     Lang = Locale:new({

--- a/locales/hu.lua
+++ b/locales/hu.lua
@@ -44,6 +44,7 @@ local Translations = {
         timemname = 'perc',
         timeh = 'Egy szám 0 - 23 között',
         timem = 'Egy szám 0 - 59 között',
+        resettimecommand = 'Visszaállítja az időt valós időre',
         freezecommand = 'Id? leállít/elindít.',
         freezeweathercommand = 'Be/Kikapcsolása a Dinamikus id?járás változásoknak',
         morningcommand = 'Id? megváltoztatva: 09:00',

--- a/locales/it.lua
+++ b/locales/it.lua
@@ -54,10 +54,6 @@ local Translations = {
         nightcommand = 'Imposta l\'ora a  23:00',
         blackoutcommand = 'Attiva/disattiva la modalità blackout.',
     },
-    error = {
-        not_access = 'Non hai accesso a quel comando.',
-        not_allowed = 'Non ti è permesso usare questo comando.',
-    }
 }
 
     Lang = Locale:new({

--- a/locales/it.lua
+++ b/locales/it.lua
@@ -46,6 +46,7 @@ local Translations = {
         timemname = 'minuti',
         timeh = 'Un numero tra 0 - 23',
         timem = 'Un numero tra 0 - 59',
+        resettimecommand = 'Riporta il tempo al tempo reale',
         freezecommand = 'Congela / scongela tempo.',
         freezeweathercommand = 'Abilita/disabilita le modifiche meteo dinamiche.',
         morningcommand = 'Imposta l\'ora a 09:00',

--- a/locales/lt.lua
+++ b/locales/lt.lua
@@ -52,10 +52,6 @@ local Translations = {
         nightcommand = 'Laikas nustatytas ? 23:00',
         blackoutcommand = 'Užtemimo nustatymas.',
     },
-    error = {
-        not_access = 'J?s neturite leidimo šiai komandai.',
-        not_allowed = 'Jums neleidžiama naudoti šios komandos.',
-    }
 }
 
     Lang = Locale:new({

--- a/locales/lt.lua
+++ b/locales/lt.lua
@@ -44,6 +44,7 @@ local Translations = {
         timemname = 'minut?s',
         timeh = 'Skai?ius tarp 0 - 23',
         timem = 'Skai?ius tarp 0 - 59',
+        resettimecommand = 'Laiko nustatymas iš naujo į realųjį laiką',
         freezecommand = 'Laiko sustabdymas.',
         freezeweathercommand = 'Or? keitimosi nustatymas.',
         morningcommand = 'Laikas nustatytas ? 09:00',

--- a/locales/nl.lua
+++ b/locales/nl.lua
@@ -52,10 +52,6 @@ local Translations = {
         nightcommand = 'Zet de tijd op 23:00',
         blackoutcommand = 'Schakel de black-outmodus.',
     },
-    error = {
-        not_access = 'Je hebt geen toegang tot die commando.',
-        not_allowed = 'Je mag dit commando niet gebruiken.',
-    }
 }
 
     Lang = Locale:new({

--- a/locales/nl.lua
+++ b/locales/nl.lua
@@ -44,6 +44,7 @@ local Translations = {
         timemname = 'minuten',
         timeh = 'Een getal tussen 0 - 23',
         timem = 'Een getal tussen 0 - 59',
+        resettimecommand = 'Zet de tijd terug naar real time',
         freezecommand = 'Tijd bevriezen / ontdooien.',
         freezeweathercommand = 'Dynamische weersveranderingen in-/uitschakelen.',
         morningcommand = 'Zet de tijd op 09:00',

--- a/locales/pt.lua
+++ b/locales/pt.lua
@@ -54,10 +54,6 @@ local Translations = {
         nightcommand = 'Definir o tempo para 23:00',
         blackoutcommand = 'Ativar/Desativar apagão.',
     },
-    error = {
-        not_access = 'Não tens acesso a este comando.',
-        not_allowed = 'Não tens permissão para usar este comando.',
-    }
 }
 
     Lang = Locale:new({

--- a/locales/pt.lua
+++ b/locales/pt.lua
@@ -46,6 +46,7 @@ local Translations = {
         timemname = 'minutos',
         timeh = 'Um número entre 0 - 23',
         timem = 'Um número entre 0 - 59',
+        resettimecommand = 'Reinicia o tempo em tempo real',
         freezecommand = 'Congelar / Descongelar o tempo.',
         freezeweathercommand = 'Ativar/Desativar as alterações dinâmicas de clima.',
         morningcommand = 'Definir o tempo para 09:00',

--- a/locales/tr.lua
+++ b/locales/tr.lua
@@ -52,10 +52,6 @@ local Translations = {
         nightcommand = 'Saati 23:00\'e ayarla',
         blackoutcommand = 'Karartma modunu aç/kapat.',
     },
-    error = {
-        not_access = 'Bu komuta erişiminiz yok.',
-        not_allowed = 'Bu komutu kullanma izniniz yok.',
-    }
 }
 
     Lang = Locale:new({

--- a/locales/tr.lua
+++ b/locales/tr.lua
@@ -44,6 +44,7 @@ local Translations = {
         timemname = 'dakika',
         timeh = '0 - 23 arasında bir sayı',
         timem = '0 - 59 arasında bir sayı',
+        resettimecommand = 'Zamanı gerçek zamana sıfırlar',
         freezecommand = 'Zamanı dondur / çöz.',
         freezeweathercommand = 'Dinamik hava durumu değişikliklerini etkinleştir/devre dışı bırak.',
         morningcommand = 'Saati 09:00\'a ayarlayın',

--- a/server/server.lua
+++ b/server/server.lua
@@ -11,7 +11,7 @@ local newWeatherTimer = Config.NewWeatherTimer
 --- @return int - source
 local function getSource(src)
     if src == '' then
-        return 0 
+        return 0
     end
     return src
 end
@@ -29,21 +29,21 @@ end
 --- Sets time offset based on minutes provided
 --- @param minute number - Minutes to offset by
 local function shiftToMinute(minute)
-    timeOffset = timeOffset - ( ( (baseTime+timeOffset) % 60 ) - minute )
+    timeOffset = timeOffset - (((baseTime + timeOffset) % 60) - minute)
 end
 
 --- Sets time offset based on hour provided
 --- @param hour number - Hour to offset by
 local function shiftToHour(hour)
-    timeOffset = timeOffset - ( ( ((baseTime+timeOffset)/60) % 24 ) - hour ) * 60
+    timeOffset = timeOffset - ((((baseTime + timeOffset) / 60) % 24) - hour) * 60
 end
 
 --- Triggers event to switch weather to next stage
 local function nextWeatherStage()
-    if CurrentWeather == "CLEAR" or CurrentWeather == "CLOUDS" or CurrentWeather == "EXTRASUNNY"  then
-        CurrentWeather = (math.random(1,5) > 2) and "CLEARING" or "OVERCAST" -- 60/40 chance
+    if CurrentWeather == "CLEAR" or CurrentWeather == "CLOUDS" or CurrentWeather == "EXTRASUNNY" then
+        CurrentWeather = (math.random(1, 5) > 2) and "CLEARING" or "OVERCAST" -- 60/40 chance
     elseif CurrentWeather == "CLEARING" or CurrentWeather == "OVERCAST" then
-        local new = math.random(1,6)
+        local new = math.random(1, 6)
         if new == 1 then CurrentWeather = (CurrentWeather == "CLEARING") and "FOGGY" or "RAIN"
         elseif new == 2 then CurrentWeather = "CLOUDS"
         elseif new == 3 then CurrentWeather = "CLEAR"
@@ -63,7 +63,7 @@ end
 --- @return boolean - success
 local function setWeather(weather)
     local validWeatherType = false
-    for _,weatherType in pairs(Config.AvailableWeatherTypes) do
+    for _, weatherType in pairs(Config.AvailableWeatherTypes) do
         if weatherType == string.upper(weather) then
             validWeatherType = true
         end
@@ -127,17 +127,9 @@ local function setDynamicWeather(state)
 end
 
 -- EVENTS
-
 RegisterNetEvent('qb-weathersync:server:RequestStateSync', function()
     TriggerClientEvent('qb-weathersync:client:SyncWeather', -1, CurrentWeather, blackout)
     TriggerClientEvent('qb-weathersync:client:SyncTime', -1, baseTime, timeOffset, freezeTime)
-end)
-
-RegisterNetEvent('qb-weathersync:server:RequestCommands', function()
-    local src = source
-    if isAllowedToChange(src) then
-        TriggerClientEvent('qb-weathersync:client:RequestCommands', src, true)
-    end
 end)
 
 RegisterNetEvent('qb-weathersync:server:setWeather', function(weather)
@@ -201,128 +193,84 @@ RegisterNetEvent('qb-weathersync:server:toggleDynamicWeather', function(state)
 end)
 
 -- COMMANDS
-
-RegisterCommand('freezetime', function(source, args, rawCommand)
-    if isAllowedToChange(source) then
-        local newstate = setTimeFreeze()
-        if source > 0 then
-            if (newstate) then return TriggerClientEvent('QBCore:Notify', source, Lang:t('time.frozenc')) end
-            return TriggerClientEvent('QBCore:Notify', source, Lang:t('time.unfrozenc'))
-        end
-        if (newstate) then return print(Lang:t('time.now_frozen')) end
-        return print(Lang:t('time.now_unfrozen'))
+QBCore.Commands.Add('freezetime', Lang:t('help.freezecommand'), {}, false, function(source, args)
+    local newstate = setTimeFreeze()
+    if source > 0 then
+        if (newstate) then return TriggerClientEvent('QBCore:Notify', source, Lang:t('time.frozenc')) end
+        return TriggerClientEvent('QBCore:Notify', source, Lang:t('time.unfrozenc'))
     end
-    TriggerClientEvent('QBCore:Notify', source, Lang:t('error.not_allowed'), 'error')
-end)
+    if (newstate) then return print(Lang:t('time.now_frozen')) end
+    return print(Lang:t('time.now_unfrozen'))
+end, 'admin')
 
-RegisterCommand('freezeweather', function(source, args, rawCommand)
-    if isAllowedToChange(source) then
-        local newstate = setDynamicWeather()
-        if source > 0 then
-            if (newstate) then return TriggerClientEvent('QBCore:Notify', source, Lang:t('dynamic_weather.enabled')) end
-            return TriggerClientEvent('QBCore:Notify', source, Lang:t('dynamic_weather.disabled'))
-        end
-        if (newstate) then return print(Lang:t('weather.now_unfrozen')) end
-        return print(Lang:t('weather.now_frozen'))
+QBCore.Commands.Add('freezeweather', Lang:t('help.freezeweathercommand'), {}, false, function(source, args)
+    local newstate = setDynamicWeather()
+    if source > 0 then
+        if (newstate) then return TriggerClientEvent('QBCore:Notify', source, Lang:t('dynamic_weather.enabled')) end
+        return TriggerClientEvent('QBCore:Notify', source, Lang:t('dynamic_weather.disabled'))
     end
-    TriggerClientEvent('QBCore:Notify', source, Lang:t('error.not_allowed'), 'error')
-end)
+    if (newstate) then return print(Lang:t('weather.now_unfrozen')) end
+    return print(Lang:t('weather.now_frozen'))
+end, 'admin')
 
-RegisterCommand('weather', function(source, args, rawCommand)
-    if isAllowedToChange(source) then
-        if args[1] == nil then
-            if source > 0 then return TriggerClientEvent('QBCore:Notify', source, Lang:t('weather.invalid_syntaxc'), 'error') end
-            return print(Lang:t('weather.invalid_syntax'))
-        end
-        local success = setWeather(args[1])
-        if source > 0 then
-            if (success) then return TriggerClientEvent('QBCore:Notify', source, Lang:t('weather.willchangeto', {value = string.lower(args[1])})) end
-            return TriggerClientEvent('QBCore:Notify', source, Lang:t('weather.invalidc'), 'error')
-        end
-        if (success) then return print(Lang:t('weather.updated')) end
-        return print(Lang:t('weather.invalid'))
-    else
-        TriggerClientEvent('QBCore:Notify', source, Lang:t('error.not_access'), 'error')
+QBCore.Commands.Add('weather', Lang:t('help.weathercommand'), {{name = Lang:t('help.weathertype'), help = Lang:t('help.availableweather')}}, true, function(source, args)
+    local success = setWeather(args[1])
+    if source > 0 then
+        if (success) then return TriggerClientEvent('QBCore:Notify', source, Lang:t('weather.willchangeto', {value = string.lower(args[1])})) end
+        return TriggerClientEvent('QBCore:Notify', source, Lang:t('weather.invalidc'), 'error')
     end
-end)
+    if (success) then return print(Lang:t('weather.updated')) end
+    return print(Lang:t('weather.invalid'))
+end, 'admin')
 
-RegisterCommand('blackout', function(source, args, rawCommand)
-    local src = source
-    if isAllowedToChange(src) then
-        local newstate = setBlackout()
-        if src > 0 then
-            if (newstate) then return TriggerClientEvent('QBCore:Notify', src, Lang:t('blackout.enabledc')) end
-            return TriggerClientEvent('QBCore:Notify', src, Lang:t('blackout.disabledc'))
-        end
-        if (newstate) then return print(Lang:t('blackout.enabled')) end
-        return print(Lang:t('blackout.disabled'))
+QBCore.Commands.Add('blackout', Lang:t('help.blackoutcommand'), {}, false, function(source, args)
+    local newstate = setBlackout()
+    if source > 0 then
+        if (newstate) then return TriggerClientEvent('QBCore:Notify', source, Lang:t('blackout.enabledc')) end
+        return TriggerClientEvent('QBCore:Notify', source, Lang:t('blackout.disabledc'))
     end
-    TriggerClientEvent('QBCore:Notify', src, Lang:t('error.not_allowed'), 'error')
-end)
+    if (newstate) then return print(Lang:t('blackout.enabled')) end
+    return print(Lang:t('blackout.disabled'))
+end, 'admin')
 
-RegisterCommand('morning', function(source, args, rawCommand)
-    if isAllowedToChange(source) then
-        setTime(9, 0)
-        if source > 0 then return TriggerClientEvent('QBCore:Notify', source, Lang:t('time.morning')) end
-    else
-        TriggerClientEvent('QBCore:Notify', source, Lang:t('error.not_allowed'), 'error')
-    end
-end)
+QBCore.Commands.Add('morning', Lang:t('help.morningcommand'), {}, false, function(source, args)
+    setTime(9, 0)
+    if source > 0 then return TriggerClientEvent('QBCore:Notify', source, Lang:t('time.morning')) end
+end, 'admin')
 
-RegisterCommand('noon', function(source, args, rawCommand)
-    if isAllowedToChange(source) then
-        setTime(12, 0)
-        if source > 0 then return TriggerClientEvent('QBCore:Notify', source, Lang:t('time.noon')) end
-    else
-        TriggerClientEvent('QBCore:Notify', source, Lang:t('error.not_allowed'), 'error')
-    end
-end)
+QBCore.Commands.Add('noon', Lang:t('help.nooncommand'), {}, false, function(source, args)
+    setTime(12, 0)
+    if source > 0 then return TriggerClientEvent('QBCore:Notify', source, Lang:t('time.noon')) end
+end, 'admin')
 
-RegisterCommand('evening', function(source, args, rawCommand)
-    if isAllowedToChange(source) then
-        setTime(18, 0)
-        if source > 0 then return TriggerClientEvent('QBCore:Notify', source, Lang:t('time.evening')) end
-    else
-        TriggerClientEvent('QBCore:Notify', source, Lang:t('error.not_allowed'), 'error')
-    end
-end)
+QBCore.Commands.Add('evening', Lang:t('help.eveningcommand'), {}, false, function(source, args)
+    setTime(18, 0)
+    if source > 0 then return TriggerClientEvent('QBCore:Notify', source, Lang:t('time.evening')) end
+end, 'admin')
 
-RegisterCommand('night', function(source, args, rawCommand)
-    if isAllowedToChange(source) then
-        setTime(23, 0)
-        if source > 0 then return TriggerClientEvent('QBCore:Notify', source, Lang:t('time.night')) end
-    else
-        TriggerClientEvent('QBCore:Notify', source, Lang:t('error.not_allowed'), 'error')
-    end
-end)
+QBCore.Commands.Add('night', Lang:t('help.nightcommand'), {}, false, function(source, args)
+    setTime(23, 0)
+    if source > 0 then return TriggerClientEvent('QBCore:Notify', source, Lang:t('time.night')) end
+end, 'admin')
 
-RegisterCommand('time', function(source, args, rawCommand)
-    if isAllowedToChange(source) then
-        if args[1] == nil then
-            if source > 0 then return TriggerClientEvent('QBCore:Notify', source, Lang:t('time.invalidc'), 'error') end
-            return print(Lang:t('time.invalid'))
-        end
-        local success = setTime(args[1], args[2])
-        if source > 0 then
-            if (success) then return TriggerClientEvent('QBCore:Notify', source, Lang:t('time.changec', {value = args[1]..':'..(args[2] or "00")})) end
-            return TriggerClientEvent('QBCore:Notify', source, Lang:t('time.invalidc'), 'error')
-        end
-        if (success) then return print(Lang:t('time.change', {value = args[1], value2 = args[2] or "00"})) end
-        return print(Lang:t('time.invalid'))
-    else
-        TriggerClientEvent('QBCore:Notify', source, Lang:t('time.access'), 'error')
+QBCore.Commands.Add('time', Lang:t('help.timecommand'), {{ name=Lang:t('help.timehname'), help=Lang:t('help.timeh') }, { name=Lang:t('help.timemname'), help=Lang:t('help.timem') }}, true, function(source, args)
+    local success = setTime(args[1], args[2])
+    if source > 0 then
+        if (success) then return TriggerClientEvent('QBCore:Notify', source, Lang:t('time.changec', {value = args[1] .. ':' .. (args[2] or "00")})) end
+        return TriggerClientEvent('QBCore:Notify', source, Lang:t('time.invalidc'), 'error')
     end
-end)
+    if (success) then return print(Lang:t('time.change', {value = args[1], value2 = args[2] or "00"})) end
+    return print(Lang:t('time.invalid'))
+end, 'admin')
 
 -- THREAD LOOPS
-
 CreateThread(function()
     local previous = 0
     while true do
         Wait(0)
-        local newBaseTime = os.time(os.date("!*t"))/2 + 360         --Set the server time depending of OS time
-        if (newBaseTime % 60) ~= previous then                      --Check if a new minute is passed
-            previous = newBaseTime % 60                             --Only update time with plain minutes, seconds are handled in the client
+        local newBaseTime = os.time(os.date("!*t")) / 2 + 360 --Set the server time depending of OS time
+        if (newBaseTime % 60) ~= previous then --Check if a new minute is passed
+            previous = newBaseTime % 60 --Only update time with plain minutes, seconds are handled in the client
             if freezeTime then
                 timeOffset = timeOffset + baseTime - newBaseTime
             end
@@ -333,7 +281,7 @@ end)
 
 CreateThread(function()
     while true do
-        Wait(2000)                                          --Change to send every minute in game sync
+        Wait(2000)--Change to send every minute in game sync
         TriggerClientEvent('qb-weathersync:client:SyncTime', -1, baseTime, timeOffset, freezeTime)
     end
 end)
@@ -359,7 +307,6 @@ CreateThread(function()
 end)
 
 -- EXPORTS
-
 exports('nextWeatherStage', nextWeatherStage)
 exports('setWeather', setWeather)
 exports('setTime', setTime)
@@ -370,4 +317,3 @@ exports('getBlackoutState', function() return blackout end)
 exports('getTimeFreezeState', function() return freezeTime end)
 exports('getWeatherState', function() return CurrentWeather end)
 exports('getDynamicWeather', function() return Config.DynamicWeather end)
-


### PR DESCRIPTION
This reworks the time sync so that time is synced with the real (ooc) time and with meaningful time calculations (see #51).

It also adds the command `resettime` to reset the time to real time after `time` was used.

Plus the commands are now handled over `QBCore.Commands`