### PR TITLE
[ENHANCEMENT] Add `getTime` export

### DIFF
--- a/server/server.lua
+++ b/server/server.lua
@@ -317,3 +317,10 @@ exports('getBlackoutState', function() return blackout end)
 exports('getTimeFreezeState', function() return freezeTime end)
 exports('getWeatherState', function() return CurrentWeather end)
 exports('getDynamicWeather', function() return Config.DynamicWeather end)
+
+exports('getTime', function()        
+    local hour = math.floor(((baseTime+timeOffset)/60)%24)
+    local minute = math.floor((baseTime+timeOffset)%60)
+
+    return hour,minute
+end)


### PR DESCRIPTION
This PR simply adds a `getTime` export to `qb-weathersync` server-side.
As `setTime` only requires `hour` and `minute` (as seconds are handled on the client side), we will only return `hour` and `minute`.
A client-side export has not been provided as the native `GetClockHours` and `GetClockMinutes` can be used instead.

**Questions:**
Q: Have you personally loaded this code into an updated qbcore project and checked all it's functionality? 
A: Yes.

Q: Does your code fit the style guidelines?
A: Yes.

Q: Does your PR fit the contribution guidelines? 
A: Yes.