### PR TITLE
Fix: "Failed to retrieve real time from API, falling back to local time"

### DIFF
--- a/server/server.lua
+++ b/server/server.lua
@@ -293,12 +293,12 @@ CreateThread(function()
                 end)
             end
             while realTimeFromApi == nil do
-                if failedCount > 60 then -- TESTING -- DEFAULT 10
+                if failedCount > 60 then
                     print("Failed to retrieve real time from API, falling back to local time")
                     break
                 end
                 failedCount = failedCount + 1
-                Wait(1000) --TESTING -- DEFAULT 100
+                Wait(1000)
             end
             if realTimeFromApi ~= nil then
                 newBaseTime = realTimeFromApi

--- a/server/server.lua
+++ b/server/server.lua
@@ -293,7 +293,7 @@ CreateThread(function()
                 end)
             end
             while realTimeFromApi == nil do
-                if failedCount > 20 then
+                if failedCount > 25 then
                     print("Failed to retrieve real time from API, falling back to local time")
                     break
                 end

--- a/server/server.lua
+++ b/server/server.lua
@@ -293,12 +293,12 @@ CreateThread(function()
                 end)
             end
             while realTimeFromApi == nil do
-                if failedCount > 15 then
+                if failedCount > 20 then
                     print("Failed to retrieve real time from API, falling back to local time")
                     break
                 end
                 failedCount = failedCount + 1
-                Wait(1000)
+                Wait(100)
             end
             if realTimeFromApi ~= nil then
                 newBaseTime = realTimeFromApi

--- a/server/server.lua
+++ b/server/server.lua
@@ -124,7 +124,7 @@ end
 --- @return number - Unix time
 local function retrieveTimeFromApi(callback)
     Citizen.CreateThread(function()
-        PerformHttpRequest("http://worldtimeapi.org/api/ip", function(statusCode, response)
+        PerformHttpRequest("https://worldtimeapi.org/api/ip", function(statusCode, response)
             if statusCode == 200 then
                 local data = json.decode(response)
                 if data == nil or data.unixtime == nil then

--- a/server/server.lua
+++ b/server/server.lua
@@ -293,12 +293,12 @@ CreateThread(function()
                 end)
             end
             while realTimeFromApi == nil do
-                if failedCount > 25 then
+                if failedCount > 60 then -- TESTING -- DEFAULT 10
                     print("Failed to retrieve real time from API, falling back to local time")
                     break
                 end
                 failedCount = failedCount + 1
-                Wait(100)
+                Wait(1000) --TESTING -- DEFAULT 100
             end
             if realTimeFromApi ~= nil then
                 newBaseTime = realTimeFromApi

--- a/server/server.lua
+++ b/server/server.lua
@@ -293,12 +293,12 @@ CreateThread(function()
                 end)
             end
             while realTimeFromApi == nil do
-                if failedCount > 10 then
+                if failedCount > 15 then
                     print("Failed to retrieve real time from API, falling back to local time")
                     break
                 end
                 failedCount = failedCount + 1
-                Wait(100)
+                Wait(1000)
             end
             if realTimeFromApi ~= nil then
                 newBaseTime = realTimeFromApi


### PR DESCRIPTION
Replaced http with https inside of retrieveTimeFromApi function.

**Describe Pull request**
This is to fix the error: "Failed to retrieve real time from API, falling back to local time"

https://github.com/qbcore-framework/qb-weathersync/issues/83

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? Yes.
- Does your code fit the style guidelines? Yes.
- Does your PR fit the contribution guidelines? Yes.
