### PR TITLE
Remove disabling on player loading

### DIFF
--- a/client/client.lua
+++ b/client/client.lua
@@ -8,7 +8,6 @@ local blackoutVehicle = Config.BlackoutVehicle
 local disable = Config.Disabled
 
 RegisterNetEvent('QBCore:Client:OnPlayerLoaded', function()
-    disable = false
     TriggerServerEvent('qb-weathersync:server:RequestStateSync')
 end)
 


### PR DESCRIPTION
This line makes no sense, at all.
It just makes the config value rather useless.